### PR TITLE
[#22] Modified face tracker processor to LargestFaceFocusingProcessor.

### DIFF
--- a/Android/toonDra/app/src/main/java/edu/kaist/mskers/toondra/FaceGraphic.java
+++ b/Android/toonDra/app/src/main/java/edu/kaist/mskers/toondra/FaceGraphic.java
@@ -22,6 +22,8 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 
+import java.util.Locale;
+
 /**
  * Graphic instance for rendering face position, orientation, and landmarks within an associated
  * graphic overlay view.
@@ -99,11 +101,14 @@ class FaceGraphic extends GraphicOverlay.Graphic {
     float ycoord = translateY(face.getPosition().y + face.getHeight() / 2);
     canvas.drawCircle(xcoord, ycoord, FACE_POSITION_RADIUS, facePositionPaint);
     canvas.drawText("id: " + faceId, xcoord + ID_X_OFFSET, ycoord + ID_Y_OFFSET, idPaint);
-    canvas.drawText("happiness: " + String.format("%.2f", face.getIsSmilingProbability()),
+    canvas.drawText("happiness: "
+        + String.format(Locale.US, "%.2f", face.getIsSmilingProbability()),
         xcoord - ID_X_OFFSET, ycoord - ID_Y_OFFSET, idPaint);
-    canvas.drawText("right eye: " + String.format("%.2f", face.getIsRightEyeOpenProbability()),
+    canvas.drawText("right eye: "
+        + String.format(Locale.US, "%.2f", face.getIsRightEyeOpenProbability()),
         xcoord + ID_X_OFFSET * 2, ycoord + ID_Y_OFFSET * 2, idPaint);
-    canvas.drawText("left eye: " + String.format("%.2f", face.getIsLeftEyeOpenProbability()),
+    canvas.drawText("left eye: "
+        + String.format(Locale.US, "%.2f", face.getIsLeftEyeOpenProbability()),
         xcoord - ID_X_OFFSET * 2, ycoord - ID_Y_OFFSET * 2, idPaint);
 
     // Draws a bounding box around the face.

--- a/Android/toonDra/app/src/main/java/edu/kaist/mskers/toondra/GraphicOverlay.java
+++ b/Android/toonDra/app/src/main/java/edu/kaist/mskers/toondra/GraphicOverlay.java
@@ -117,7 +117,7 @@ public class GraphicOverlay extends View {
     public void postInvalidate() {
       overlay.postInvalidate();
     }
-  }
+  }  // Graphic class
 
   public GraphicOverlay(Context context, AttributeSet attrs) {
     super(context, attrs);


### PR DESCRIPTION
fixes #22 
- use LargestFaceFocusingProcessor instead of MultiProcessor since we need to detect only single face for scrolling
- keep FaceGraphic class as it is - although most of the features are useless for now
- does not immediately remove face item and overlay at onMissing() - since we are using only one face, it does not need to remove and recreate the user's face.
- minor fixes to string formatting
